### PR TITLE
Trigger next turn on card click

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ Gebaut mit **Python Flask**, HTML/CSS und JavaScript für interaktive Animatione
 - Mehrspieler-Modus (lokal)
 - Flip-Animation der Karten (erst klicken, dann Effekt!)
 - Zufällige Spielfeldstruktur (wird bei Karte 4 neu gemischt)
-- Karte bleibt offen, bis der nächste Spieler klickt
+- Karte bleibt offen; zum Weiterspielen einfach auf die Karte klicken (kein Extra-Button nötig)
 - Kein Spoiler: Effekt kommt **erst nach Flip**
 - Spielerwechsel automatisch

--- a/templates/spiel.html
+++ b/templates/spiel.html
@@ -134,9 +134,6 @@
             <div class="info">
                 <p>{{ karotten_feld }}</p>
             </div>
-            <form action="{{ url_for('spiel') }}" method="get">
-                <button type="submit" class="naechster-button">🎯 Nächster Spieler</button>
-            </form>
         </div>
         <div id="svg-board"
              data-spieler='{{ spieler_json|safe }}'
@@ -186,6 +183,7 @@
                     letzteKarteStapel.src = gezogeneKarteSrc;
                     letzteKarteStapel.style.display = "block";
                     clone.remove();
+                    window.location.href = "{{ url_for('spiel') }}";
                 }, 900);
             }, 3000);
         }


### PR DESCRIPTION
## Summary
- remove now-unused "Nächster Spieler" button
- reload the game when the big card is clicked
- update feature list in README

## Testing
- `python -m py_compile Shoty_01.py players.py`


------
https://chatgpt.com/codex/tasks/task_e_684bfa34bb7083298c2bf6b71ef0b246