### PR TITLE
Trigger board update after card click

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ Gebaut mit **Python Flask**, HTML/CSS und JavaScript für interaktive Animatione
 - Mehrspieler-Modus (lokal)
 - Flip-Animation der Karten (erst klicken, dann Effekt!)
 - Zufällige Spielfeldstruktur (wird bei Karte 4 neu gemischt)
-- Karte bleibt offen, bis der nächste Spieler klickt
-- Kein Spoiler: Effekt kommt **erst nach Flip**
+- Karte bleibt offen; zum Weiterspielen einfach auf die Karte klicken (kein Extra-Button nötig)
+- Spielfeld-Update kommt **erst nach dem Flip**
 - Spielerwechsel automatisch

--- a/Shoty_01.py
+++ b/Shoty_01.py
@@ -33,29 +33,19 @@ def spiel_starten():
 @app.route('/spiel')
 def spiel():
     spieler = [Player.from_dict(p) for p in session['spieler']]
-    felder = session['felder']
     aktueller_spieler_idx = session['aktueller_spieler']
 
-    aktueller_spieler = spieler[aktueller_spieler_idx]
-    karte = random.randint(1, 5)
-    karotten_feld = ""
+    # Nachricht aus dem letzten Zug anzeigen, dann entfernen
+    karotten_feld = session.pop('karotten_feld', '')
 
-    if karte in [1, 2, 3]:
-        aktueller_spieler.move(karte)
-        karotten_feld = check_position(aktueller_spieler.position)
-        if karotten_feld == "Du bist in ein Loch geflogen! Sauf!":
-            aktueller_spieler.position = 0
+    # Karte nur ziehen, wenn noch keine für diesen Zug existiert
+    karte = session.get('gezogene_karte')
+    if karte is None:
+        karte = random.randint(1, 5)
+        session['gezogene_karte'] = karte
 
-    elif karte == 4:
-        random.shuffle(felder)
-        karotten_feld = check_position(aktueller_spieler.position)
-
-    # 🎴 Mapping zur Bilddatei
+    # 🎴 Bilddatei der gezogenen Karte
     gezogene_karte = f"karte_{karte}.png"
-
-    session['spieler'] = [p.to_dict() for p in spieler]
-    session['felder'] = felder
-    session['aktueller_spieler'] = (aktueller_spieler_idx + 1) % len(spieler)
 
     spieler_namen = [p.name for p in spieler]
     counter = [p.position for p in spieler]
@@ -68,6 +58,36 @@ def spiel():
                            gezogene_karte=gezogene_karte,
                            zip=zip,
                            spieler_json=json.dumps([p.to_dict() for p in spieler]))
+
+@app.route('/apply_card')
+def apply_card():
+    spieler = [Player.from_dict(p) for p in session['spieler']]
+    felder = session['felder']
+    aktueller_spieler_idx = session['aktueller_spieler']
+
+    karte = session.pop('gezogene_karte', None)
+    if karte is None:
+        return redirect(url_for('spiel'))
+
+    aktueller_spieler = spieler[aktueller_spieler_idx]
+    karotten_feld = ""
+
+    if karte in [1, 2, 3]:
+        aktueller_spieler.move(karte)
+        karotten_feld = check_position(aktueller_spieler.position)
+        if karotten_feld == "Du bist in ein Loch geflogen! Sauf!":
+            aktueller_spieler.position = 0
+
+    elif karte == 4:
+        random.shuffle(felder)
+        karotten_feld = check_position(aktueller_spieler.position)
+
+    session['spieler'] = [p.to_dict() for p in spieler]
+    session['felder'] = felder
+    session['aktueller_spieler'] = (aktueller_spieler_idx + 1) % len(spieler)
+    session['karotten_feld'] = karotten_feld
+
+    return redirect(url_for('spiel'))
 
 
 def check_position(position):

--- a/templates/spiel.html
+++ b/templates/spiel.html
@@ -134,9 +134,6 @@
             <div class="info">
                 <p>{{ karotten_feld }}</p>
             </div>
-            <form action="{{ url_for('spiel') }}" method="get">
-                <button type="submit" class="naechster-button">🎯 Nächster Spieler</button>
-            </form>
         </div>
         <div id="svg-board"
              data-spieler='{{ spieler_json|safe }}'
@@ -186,6 +183,7 @@
                     letzteKarteStapel.src = gezogeneKarteSrc;
                     letzteKarteStapel.style.display = "block";
                     clone.remove();
+                    window.location.href = "{{ url_for('apply_card') }}";
                 }, 900);
             }, 3000);
         }


### PR DESCRIPTION
## Summary
- postpone board update until card is clicked
- add new `/apply_card` route to process the drawn card
- update JS to redirect to the new route after the card animation
- document that the board updates only after flipping the card

## Testing
- `python -m py_compile Shoty_01.py players.py`


------
https://chatgpt.com/codex/tasks/task_e_684bfa34bb7083298c2bf6b71ef0b246