### PR TITLE
Fix card flow and players stuck bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Gebaut mit **Python Flask**, HTML/CSS und JavaScript für interaktive Animatione
 - Mehrspieler-Modus (lokal)
 - Flip-Animation der Karten (erst klicken, dann Effekt!)
 - Zufällige Spielfeldstruktur (wird bei Karte 4 neu gemischt)
-- Karte bleibt offen, bis der nächste Spieler klickt
-- Kein Spoiler: Effekt kommt **erst nach Flip**
+- Karte bleibt offen; zum Weiterspielen einfach auf die Karte klicken (kein Extra-Button nötig)
+- Spielfeld-Update erscheint direkt nach dem Flip,
+  danach wandert die Karte automatisch nach unten
 - Spielerwechsel automatisch

--- a/static/script.js
+++ b/static/script.js
@@ -1,11 +1,6 @@
-window.onload = () => {
+function renderBoard(spieler, aktueller) {
     const board = document.getElementById("svg-board");
     board.innerHTML = "";
-
-    // Spieler-Infos aus Data-Attribut holen
-    const spielerData = board.getAttribute("data-spieler");
-    const spieler = spielerData ? JSON.parse(spielerData) : [];
-    const aktueller = board.getAttribute("data-aktueller");
 
     // Snake-Board Parameter
     const FELDER = 31; // 0 (Start) bis 30
@@ -194,4 +189,12 @@ window.onload = () => {
     }
 
     board.appendChild(svg);
+};
+
+window.onload = () => {
+    const board = document.getElementById("svg-board");
+    const spielerData = board.getAttribute("data-spieler");
+    const spieler = spielerData ? JSON.parse(spielerData) : [];
+    const aktueller = board.getAttribute("data-aktueller");
+    renderBoard(spieler, aktueller);
 };

--- a/templates/spiel.html
+++ b/templates/spiel.html
@@ -134,9 +134,6 @@
             <div class="info">
                 <p>{{ karotten_feld }}</p>
             </div>
-            <form action="{{ url_for('spiel') }}" method="get">
-                <button type="submit" class="naechster-button">🎯 Nächster Spieler</button>
-            </form>
         </div>
         <div id="svg-board"
              data-spieler='{{ spieler_json|safe }}'
@@ -149,45 +146,51 @@
             const karte = document.getElementById('karte');
             const stapel = document.getElementById('kartenstapel');
             const letzteKarteStapel = document.getElementById('letzte-karte-stapel');
-            // Die gezogene Karte (Vorderseite) als Bildquelle holen
             const gezogeneKarteSrc = document.querySelector('.vorderseite img').src;
+
+            // Doppelklick verhindern
+            container.onclick = null;
 
             container.classList.add('flip');
 
-            // Nach 3 Sekunden: animiere Karte zum Stapel
+            // Nach dem Flip per AJAX Zug ausführen
             setTimeout(() => {
-                // Positionen berechnen
-                const karteRect = karte.getBoundingClientRect();
-                const stapelRect = stapel.getBoundingClientRect();
-                const dx = stapelRect.left + stapelRect.width/2 - (karteRect.left + karteRect.width/2);
-                const dy = stapelRect.top + stapelRect.height/2 - (karteRect.top + karteRect.height/2);
+                fetch("{{ url_for('apply_card') }}?ajax=1")
+                    .then(r => r.json())
+                    .then(data => {
+                        document.querySelector('.info p').textContent = data.karotten_feld;
+                        renderBoard(data.spieler, data.aktueller);
 
-                // Klone die Karte für die Animation
-                const clone = karte.cloneNode(true);
-                clone.style.position = "fixed";
-                clone.style.left = karteRect.left + "px";
-                clone.style.top = karteRect.top + "px";
-                clone.style.margin = "0";
-                clone.style.zIndex = 1000;
-                clone.style.transition = "transform 0.8s cubic-bezier(.4,2,.6,1), opacity 0.8s";
-                document.body.appendChild(clone);
+                        // Positionen berechnen
+                        const karteRect = karte.getBoundingClientRect();
+                        const stapelRect = stapel.getBoundingClientRect();
+                        const dx = stapelRect.left + stapelRect.width/2 - (karteRect.left + karteRect.width/2);
+                        const dy = stapelRect.top + stapelRect.height/2 - (karteRect.top + karteRect.height/2);
 
-                // Karte zurückdrehen (Original)
-                container.classList.remove('flip');
+                        const clone = karte.cloneNode(true);
+                        clone.style.position = "fixed";
+                        clone.style.left = karteRect.left + "px";
+                        clone.style.top = karteRect.top + "px";
+                        clone.style.margin = "0";
+                        clone.style.zIndex = 1000;
+                        clone.style.transition = "transform 0.8s cubic-bezier(.4,2,.6,1), opacity 0.8s";
+                        document.body.appendChild(clone);
 
-                // Nach kurzem Timeout animieren
-                setTimeout(() => {
-                    clone.style.transform = `translate(${dx}px,${dy}px) scale(0.3) rotate(10deg)`;
-                    clone.style.opacity = "0.2";
-                }, 30);
+                        container.classList.remove('flip');
 
-                // Nach Animation: Stapel-Bild sichtbar machen und Bild setzen
-                setTimeout(() => {
-                    letzteKarteStapel.src = gezogeneKarteSrc;
-                    letzteKarteStapel.style.display = "block";
-                    clone.remove();
-                }, 900);
-            }, 3000);
+                        setTimeout(() => {
+                            clone.style.transform = `translate(${dx}px,${dy}px) scale(0.3) rotate(10deg)`;
+                            clone.style.opacity = "0.2";
+                        }, 30);
+
+                        setTimeout(() => {
+                            letzteKarteStapel.src = gezogeneKarteSrc;
+                            letzteKarteStapel.style.display = "block";
+                            clone.remove();
+                            window.location.href = "{{ url_for('spiel') }}";
+                        }, 900);
+                    });
+            }, 800);
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- refresh board immediately after a card flip via an AJAX call
- return JSON from `/apply_card` for AJAX requests
- update JS board rendering into a reusable `renderBoard` function
- reload the game after the animation to show the next card
- document the new flow

## Testing
- `python -m py_compile Shoty_01.py players.py`
- manual Flask test client checks for JSON response

------
https://chatgpt.com/codex/tasks/task_e_684bfa34bb7083298c2bf6b71ef0b246